### PR TITLE
When state query parameter is empty string, generated signature is not valid.

### DIFF
--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -16,9 +16,11 @@ class CompletePurchaseRequest extends AbstractRequest
         $data['resource_uri'] = $this->httpRequest->get('resource_uri');
         $data['resource_id'] = $this->httpRequest->get('resource_id');
         $data['resource_type'] = $this->httpRequest->get('resource_type');
-        if ($this->httpRequest->get('state')) {
+
+        if (! is_null($this->httpRequest->get('state'))) {
             $data['state'] = $this->httpRequest->get('state');
         }
+
 
         if ($this->generateSignature($data) !== $this->httpRequest->get('signature')) {
             throw new InvalidResponseException;

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -49,6 +49,26 @@ class GatewayTest extends GatewayTestCase
         $this->assertEquals('b', $response->getTransactionReference());
     }
 
+    public function testCompletePurchaseSuccessWithEmptyStateVariable()
+    {
+        $this->getHttpRequest()->request->replace(
+            array(
+                'resource_uri' => 'a',
+                'resource_id' => 'b',
+                'resource_type' => 'c',
+                'state' => '',
+                'signature' => '32189fc3f76bfeacb279a911116256d0ab399ecc33f3c74987564d73bb390c6a',
+            )
+        );
+
+        $this->setMockHttpResponse('CompletePurchaseSuccess.txt');
+
+        $response = $this->gateway->completePurchase($this->options)->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals('b', $response->getTransactionReference());
+    }
+
     public function testCompletePurchaseError()
     {
         $this->getHttpRequest()->request->replace(


### PR DESCRIPTION
Therefore, we still need to pass it to the generateSignature method even it is empty string.
